### PR TITLE
fix the issue clouldn't excute  command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@
 #    By: ichikawahikaru <ichikawahikaru@student.    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/10/14 16:40:32 by ichikawahik       #+#    #+#              #
+<<<<<<< Updated upstream
 #    Updated: 2025/11/22 05:15:45 by ichikawahik      ###   ########.fr        #
+=======
+#    Updated: 2025/11/22 15:50:05 by ichikawahik      ###   ########.fr        #
+>>>>>>> Stashed changes
 #                                                                              #
 # **************************************************************************** #
 
@@ -30,6 +34,16 @@ SRCS = srcs/main.c\
 	   srcs/pipe/pipe.c\
 	   srcs/exec/exec.c\
 	   srcs/signal/signal.c\
+<<<<<<< Updated upstream
+=======
+	   srcs/builtin/builtin.c\
+	   srcs/builtin/builtin_exit.c\
+	   srcs/builtin/builtin_export.c\
+	   srcs/builtin/builtin_unset.c\
+	   srcs/builtin/builtin_env.c\
+	   srcs/builtin/builtin_cd.c\
+	   srcs/builtin/builtin_pwd.c\
+>>>>>>> Stashed changes
 	   srcs/hashstamp/map.c\
 	   srcs/hashstamp/env.c\
 	   srcs/builtin/builtin.c\

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -6,7 +6,11 @@
 /*   By: ichikawahikaru <ichikawahikaru@student.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/18 21:55:05 by ichikawahik       #+#    #+#             */
+<<<<<<< Updated upstream
 /*   Updated: 2025/11/22 08:18:50 by ichikawahik      ###   ########.fr       */
+=======
+/*   Updated: 2025/11/22 15:59:55 by ichikawahik      ###   ########.fr       */
+>>>>>>> Stashed changes
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -95,6 +99,26 @@ void	validate_access(const char *path, const char *filename)
 // X_OK for execute/search permission), or the existence test (F_OK)
 // F_OK：そのパスが「存在するか？」だけを調べる chmodとかでは扱わないフラグ
 
+<<<<<<< Updated upstream
+=======
+int	exec_nonbuiltin(t_node *node)
+{
+	char	*path;
+	char	**argv;
+
+	do_redirect(node->command->redirects);
+	argv = token_list_to_argv(node->command->args);
+	path = argv[0];
+	if (strchr(path, '/') == NULL)
+		path = search_path(path);
+	validate_access(path, argv[0]);
+	execve(path, argv, get_environ(envmap));
+	free_argv(argv);
+	reset_redirect(node->command->redirects);
+	fatal_error("execve");
+}
+
+>>>>>>> Stashed changes
 pid_t	exec_pipeline(t_node *node)
 {
 	const char *path;


### PR DESCRIPTION
This pull request mainly adds the implementation for executing non-builtin commands and updates the build configuration to include more builtin command source files. There are also minor updates to file headers.

**Execution logic improvements:**

* Added the `exec_nonbuiltin` function in `srcs/exec/exec.c`, which handles running external (non-builtin) commands by preparing arguments, searching for the executable in the `PATH` if necessary, validating access, and invoking `execve`. It also manages redirection and error handling.

**Build configuration updates:**

* Updated the `SRCS` variable in the `Makefile` to include additional builtin command source files: `builtin_exit.c`, `builtin_export.c`, `builtin_unset.c`, `builtin_env.c`, `builtin_cd.c`, and `builtin_pwd.c`.

**Minor changes:**

* Updated file headers in both `Makefile` and `srcs/exec/exec.c` to reflect the latest modification dates. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R9-R13) [[2]](diffhunk://#diff-9dc5f5d228359036397dc86c577d4963c439e55e0a5fb9a5763eef569af8a174R9-R13)