### PR TITLE
fix the issues.

### DIFF
--- a/srcs/builtin/builtin_cd.c
+++ b/srcs/builtin/builtin_cd.c
@@ -6,7 +6,7 @@
 /*   By: ichikawahikaru <ichikawahikaru@student.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/22 14:04:45 by ichikawahik       #+#    #+#             */
-/*   Updated: 2025/11/22 15:35:07 by ichikawahik      ###   ########.fr       */
+/*   Updated: 2025/11/22 17:20:24 by ichikawahik      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -116,7 +116,7 @@ int	builtin_cd(char **argv)
 	char	*newpwd;
 
 	oldpwd = map_get(envmap, "PWD");
-	map_set(envmap, "OLDPQD", oldpwd);
+	map_set(envmap, "OLDPWD", oldpwd);
 	if (argv[1] == NULL)
 	{
 		home = map_get(envmap, "HOME");

--- a/srcs/builtin/builtin_exit.c
+++ b/srcs/builtin/builtin_exit.c
@@ -6,7 +6,7 @@
 /*   By: ichikawahikaru <ichikawahikaru@student.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/22 10:38:10 by ichikawahik       #+#    #+#             */
-/*   Updated: 2025/11/22 11:05:31 by ichikawahik      ###   ########.fr       */
+/*   Updated: 2025/11/22 17:20:24 by ichikawahik      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,7 +43,7 @@ int	builtin_exit(char **argv)
 		return (1);
 	}
 	arg = argv[1];
-	if (!is_numeric(arg))
+	if (is_numeric(arg))
 	{
 		errno = 0;
 		res = strtol(arg, &endptr, 10);

--- a/srcs/builtin/builtin_unset.c
+++ b/srcs/builtin/builtin_unset.c
@@ -6,7 +6,7 @@
 /*   By: ichikawahikaru <ichikawahikaru@student.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/22 13:39:01 by ichikawahik       #+#    #+#             */
-/*   Updated: 2025/11/22 13:41:54 by ichikawahik      ###   ########.fr       */
+/*   Updated: 2025/11/22 17:20:24 by ichikawahik      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,8 +26,6 @@ int	builtin_unset(char **argv)
 			builtin_error("unset", argv[i], "not a valid identifier");
 			status = 1;
 		}
-		else
-			status = 0;
 		i++;
 	}
 	return (status);

--- a/srcs/redirection/redirect.c
+++ b/srcs/redirection/redirect.c
@@ -6,7 +6,7 @@
 /*   By: ichikawahikaru <ichikawahikaru@student.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/12 05:58:26 by ichikawahik       #+#    #+#             */
-/*   Updated: 2025/11/22 07:40:50 by ichikawahik      ###   ########.fr       */
+/*   Updated: 2025/11/22 17:20:24 by ichikawahik      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -100,7 +100,6 @@ int	open_redir_file(t_node *node)
 			xperror(node->filename->word);
 		return (-1);
 	}
-	node->stashed_targetfd = stashfd(node->targetfd);
 	return (open_redir_file(node->next));
 }
 


### PR DESCRIPTION
This pull request addresses several bug fixes and minor code cleanups in the built-in shell commands and redirection logic. The most important changes focus on correcting environment variable handling in `cd`, fixing argument validation in `exit`, and removing unnecessary code in `unset` and redirection.

**Bug fixes and logic corrections:**

* Fixed a typo in the environment variable name from `"OLDPQD"` to `"OLDPWD"` when updating the previous working directory in `builtin_cd`.
* Corrected the logic in `builtin_exit` to properly check if the argument is numeric before attempting to convert it to a number.

**Code cleanup and simplification:**

* Removed unnecessary resetting of `status` to 0 inside the loop in `builtin_unset`, ensuring the function returns the correct status if any invalid identifier is found.
* Removed an unused line that stashed the target file descriptor in `open_redir_file`, likely as part of code cleanup or a refactor.

**General:**

* Updated file headers to reflect the latest modification date and author changes. [[1]](diffhunk://#diff-78f716ca7bd59100892f60c1b3fb81e9bfbf35a5aebae2e0025d01fa71064e7aL9-R9) [[2]](diffhunk://#diff-ad007a9243b33be18c74945d8baa089d1bf9290cbe9b2d74c0d26b84cbc7de87L9-R9) [[3]](diffhunk://#diff-6648917c781d91890054683997ec47ad00dc463392c3a7f14b2689b372704090L9-R9) [[4]](diffhunk://#diff-6bfdded7fb5933b418141e14f471169bd03b469fdc9d80e9bfa79ae931c1dcb1L9-R9)