### PR TITLE
reason why did't work: using ";" .sh file Link readline and reorder link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ OBJS = $(SRCS:%.c=%.o)
 all: $(NAME)
 
 $(NAME): $(OBJS) $(LIBFT)
-	$(CC) $(CFLAGS) -o $(NAME) $(OBJS) $(LIBS)
+	$(CC) $(OBJS) $(LIBFT) $(CFLAGS) -lreadline -o $(NAME)
 
 $(LIBFT):
 	make -C $(LIBFT_DIR) all bonus

--- a/srcs/builtin/builtin_pwd.c
+++ b/srcs/builtin/builtin_pwd.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include <linux/limits.h>
+// #include <linux/limits.h>
 #include <unistd.h>
 #include <limits.h>
 #include <sys/stat.h>

--- a/srcs/hashstamp/env.c
+++ b/srcs/hashstamp/env.c
@@ -11,7 +11,7 @@
 /* ************************************************************************** */
 
 #include <stdlib.h>
-#include <linux/limits.h>
+// #include <linux/limits.h>
 #include <unistd.h>
 #include <limits.h>
 #include "minishell.h"

--- a/test/test.sh
+++ b/test/test.sh
@@ -246,7 +246,7 @@ test_2(){
 # ----------------------------------------3----------------------------------------
 test_3(){
 	# redirect
-	ptrintf "# redirect\n"
+	printf "# redirect\n"
 	## Redirecting output
 	printf "## Redirecting output\n"
 	assert 'echo hello >hello.txt' 'hello.txt'
@@ -312,7 +312,103 @@ test_4(){
 # ----------------------------------------4----------------------------------------
 
 # ----------------------------------------5----------------------------------------
+ 
+ 
+# test_5(){
+	
+# 	# Signal
+# 	printf "# Signal\n"
+# 	echo "int main() {while (1);}" | cc -xc -o infinite_loop -
+# 	 # `-xc`: 入力がファイルではないため、ソースの言語をC言語と明示
+# 	 # `-o infinite_loop`: 出力される実行可能ファイル名を `infinite_loop` に指定
+# 	 # `-`: ソースコードをファイルからではなく、標準入力から読み込み
+		
+# 	## Signal to shell processes
+# 	print_desc "SIGTERM to SHELL"
+# 	(sleep 0.1
+# 	 pkill -SIGTERM bash 2>/dev/null
+# 	 pkill -SIGTERM infinite_loop 2>/dev/null
+# 	 sleep 0.1
+# 	 pkill -SIGTERM minishell 2>/dev/null
+# 	 pkill -SIGTERM infinite_loop 2>/dev/null
+# 	 sleep 0.1
+# 	 pkill -SIGTERM bash 2>/dev/null
+# 	 pkill -SIGTERM infinite_loop 2>/dev/null) & BGPID=$!
+# 	assert './infinite_loop' 2>/dev/null
+# 	wait $BGPID 2>/dev/null
+# 	 ###目標:SIGTERMが成功する
+	
+# 	print_desc "SIGQUIT to SHELL"
+# 	(sleep 0.1
+# 	 pkill -SIGQUIT bash 2>/dev/null # SIGQUITシグナルを正しく【無視】する
+# 	 sleep 0.1
+# 	 pkill -SIGTERM bash 2>/dev/null
+# 	 pkill -SIGTERM infinite_loop 2>/dev/null
+# 	 sleep 0.1
+# 	 pkill -SIGQUIT minishell 2>/dev/null # SIGQUITシグナルを正しく【無視】する
+# 	 sleep 0.1
+# 	 pkill -SIGTERM minishell 2>/dev/null
+# 	 pkill -SIGTERM infinite_loop 2>/dev/null) & BGPID=$!
+# 	assert './infinite_loop' 2>/dev/null
+# 	wait $BGPID 2>/dev/null
+# 	 ### SIGQUIT がshellをkillしない
+	
+# 	print_desc "SIGINT to SHELL"
+# 	(sleep 0.1
+# 	 pkill -SIGINT bash 2>/dev/null # SIGINTシグナルを正しく【無視】する
+# 	 sleep 0.1
+# 	 pkill -SIGTERM bash 2>/dev/null
+# 	 pkill -SIGTERM infinite_loop 2>/dev/null
+# 	 sleep 0.1
+# 	 pkill -SIGINT minishell 2>/dev/null # SIGINTシグナルを正しく【無視】する
+# 	 sleep 0.1
+# 	 pkill -SIGTERM minishell 2>/dev/null
+# 	 pkill -SIGTERM infinite_loop 2>/dev/null) & BGPID=$!
+# 	assert './infinite_loop' 2>/dev/null
+# 	wait $BGPID 2>/dev/null
+# 	 ### SIGINT がshellをkillしない
+	
+	
+# 	## Signal to child processes すべて正常に終了・中断すること
+# 	print_desc "SITERM to child process"
+# 	(sleep 0.1
+# 	 pkill -SIGTERM infinite_loop 2>/dev/null
+# 	 sleep 0.1
+# 	 pkill -SIGTERM infinite_loop 2>/dev/null) & BGPID=$!
+# 	assert './infinite_loop'
+# 	wait $BGPID 2>/dev/null
+# 	 # 1回目にbash 2回目にminishell の子プロセス がターゲットに
+	
+# 	print_desc "SIGQUIT to child process"
+# 	(sleep 0.1
+# 	 pkill -SIGQUIT infinite_loop 2>/dev/null
+# 	 sleep 0.1
+# 	 pkill -SIGQUIT infinite_loop 2>/dev/null) & BGPID=$!
+# 	assert './infinite_loop'
+# 	wait $BGPID 2>/dev/null
+	
+# 	print_desc "SIGINT to child process"
+# 	(sleep 0.1
+# 	 pkill -SIGINT infinite_loop 2>/dev/null
+# 	 sleep 0.1
+# 	 pkill -SIGINT infinite_loop 2>/dev/null) & BGPID=$!
+# 	assert './infinite_loop'
+# 	wait $BGPID 2>/dev/null
+	
+# 	print_desc "SIGUSR1 to child process"
+# 	(sleep 0.1
+# 	 pkill -SIGUSR1 infinite_loop 2>/dev/null
+# 	 sleep 0.1
+# 	 pkill -SIGUSR1 infinite_loop 2>/dev/null) & BGPID=$!
+# 	assert './infinite_loop'
+# 	wait $BGPID 2>/dev/null
+# 	 #infinite_loopにはSIGUSR1受け取りの動作がないので、
+# 	 #SIGUSR1のデフォルト動作である「プロセスの終了」が実行されることを確認
+# 	echo
+# }
+# 
 test_5(){
+	#0
 	# Signal
 	printf "# Signal\n"
 	echo "int main() {while (1);}" | cc -xc -o infinite_loop -
@@ -322,53 +418,86 @@ test_5(){
 	
 	## Signal to shell processes
 	print_desc "SIGTERM to SHELL"
-	(sleep 0.1; pkill -SIGTERM bash;
-	 sleep 0.1; pkill -SIGTERM minishell) &
+	(
+		sleep 0.1
+		pkill -SIGTERM bash
+		sleep 0.1
+		pkill -SIGTERM minishell
+	) &
 	assert './infinite_loop' 2>/dev/null
 	 ###目標:SIGTERMが成功する
 	
 	print_desc "SIGQUIT to SHELL"
-	(sleep 0.1; pkill -SIGQUIT bash; # SIGQUITシグナルを正しく【無視】する
-	 sleep 0.1; pkill -SIGTERM bash;
-	 sleep 0.1; pkill -SIGQUIT minishell; # SIGQUITシグナルを正しく【無視】する
-	 sleep 0.1; pkill -SIGTERM minishell) &
+	(
+		sleep 0.1
+		pkill -SIGQUIT bash # SIGQUITシグナルを正しく【無視】する
+		sleep 0.1
+		pkill -SIGTERM bash
+		sleep 0.1
+		pkill -SIGQUIT minishell # SIGQUITシグナルを正しく【無視】する
+		sleep 0.1
+		pkill -SIGTERM minishell
+	) &
 	assert './infinite_loop' 2>/dev/null
 	 ### SIGQUIT がshellをkillしない
 	
 	print_desc "SIGINT to SHELL"
-	(sleep 0.1; pkill -SIGINT bash; # SIGINTシグナルを正しく【無視】する
-	 sleep 0.1; pkill -SIGTERM bash;
-	 sleep 0.1; pkill -SIGINT minishell; # SIGINTシグナルを正しく【無視】する
-	 sleep 0.1; pkill -SIGTERM minishell) &
+	(
+		sleep 0.1
+		pkill -SIGINT bash # SIGINTシグナルを正しく【無視】する
+		sleep 0.1
+		pkill -SIGTERM bash
+		sleep 0.1
+		pkill -SIGINT minishell # SIGINTシグナルを正しく【無視】する
+		sleep 0.1
+		pkill -SIGTERM minishell
+	) &
 	assert './infinite_loop' 2>/dev/null
 	 ### SIGINT がshellをkillしない
 	
 	
 	## Signal to child processes すべて正常に終了・中断すること
 	print_desc "SITERM to child process"
-	(sleep 0.1; pkill -SIGTERM infinite_loop;
-	 sleep 0.1; pkill -SIGTERM infinite_loop) &
+	(
+		sleep 0.1
+		pkill -SIGTERM infinite_loop
+		sleep 0.1
+		pkill -SIGTERM infinite_loop
+	) &
 	assert './infinite_loop'
 	 # 1回目にbash 2回目にminishell の子プロセス がターゲットに
 	
 	print_desc "SIGQUIT to child process"
-	(sleep 0.1; pkill -SIGQUIT infinite_loop;
-	 sleep 0.1; pkill -SIGQUIT infinite_loop) &
+	(
+		sleep 0.1
+		pkill -SIGQUIT infinite_loop
+		sleep 0.1
+		pkill -SIGQUIT infinite_loop
+	) &
 	assert './infinite_loop'
 	
 	print_desc "SIGINT to child process"
-	(sleep 0.1; pkill -SIGINT infinite_loop;
-	 sleep 0.1; pkill -SIGINT infinite_loop) &
+	(
+		sleep 0.1
+		pkill -SIGINT infinite_loop
+		sleep 0.1
+		pkill -SIGINT infinite_loop
+	) &
 	assert './infinite_loop'
 	
 	print_desc "SIGUSR1 to child process"
-	(sleep 0.1; pkill -SIGUSR1 infinite_loop;
-	 sleep 0.1; pkill -SIGUSR1 infinite_loop) &
+	(
+		sleep 0.1
+		pkill -SIGUSR1 infinite_loop
+		sleep 0.1
+		pkill -SIGUSR1 infinite_loop
+	) &
 	assert './infinite_loop'
 	 #infinite_loopにはSIGUSR1受け取りの動作がないので、
 	 #SIGUSR1のデフォルト動作である「プロセスの終了」が実行されることを確認
 	echo
 }
+
 # ----------------------------------------5----------------------------------------
  
 # Manual Debug
@@ -490,7 +619,7 @@ test_9(){
 	assert 'unset HOME\ncd \n echo $PWD'
 	echo
 }
-# ----------------------------------------9---------------------------------------- 
+# ----------------------------------------9----------------------------------------
 
 # ----------------------------------------10---------------------------------------- 
 test_10(){


### PR DESCRIPTION
This pull request includes several improvements and fixes across the Makefile, source files, and test scripts. The most significant changes are focused on build process adjustments, portability improvements, and enhanced test coverage and clarity for signal handling.

**Build and Portability Improvements:**

* The `Makefile` linking command was updated to ensure that `$(LIBFT)` is explicitly linked and the order of flags and libraries is corrected, which can help resolve linking issues and ensure proper build behavior. (`Makefile`)
* Replaced `#include <linux/limits.h>` with a commented-out version and ensured `#include <limits.h>` is used instead in both `builtin_pwd.c` and `env.c`, improving portability across different Unix-like systems. (`srcs/builtin/builtin_pwd.c`, `srcs/hashstamp/env.c`) [[1]](diffhunk://#diff-c84ca012016768f4ce42f54a16bb1d0ec9b54d5322a0dd5699c220348a71bc2fL13-R13) [[2]](diffhunk://#diff-b1a42f184da84d3445c457c429ed4b7f98320fa8e5b72c737101a43cba8b4733L14-R14)

**Test Script Enhancements and Fixes:**

* Fixed a typo in the test script (`test.sh`) by changing `ptrintf` to `printf`, ensuring the script outputs correctly. (`test/test.sh`)
* Refactored signal handling tests in `test_5` to use more readable multi-line subshells, making the test logic clearer and easier to maintain. (`test/test.sh`)
* Added a large commented-out block with an alternative, more detailed version of signal handling tests, potentially for future reference or debugging. (`test/test.sh`)

These changes collectively improve the reliability, portability, and maintainability of the build process and test suite.