### PR TITLE
Add command_not_found_error and quiet Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,17 +81,18 @@ OBJS = $(SRCS:%.c=%.o)
 all: $(NAME)
 
 $(NAME): $(OBJS) $(LIBFT)
-	$(CC) -o $(NAME) $(OBJS) $(LDFLAGS) $(LIBS) 
+	@$(CC) -o $(NAME) $(OBJS) $(LDFLAGS) $(LIBS) 
 	
 %.o: %.c
-	$(CC) $(CFLAGS) -c $< -o $@
+	@$(CC) $(CFLAGS) -c $< -o $@
 	
 $(LIBFT):
-	+$(MAKE) -C $(LIBFT_DIR) all bonus
+	@+$(MAKE) -C $(LIBFT_DIR) all bonus
 
 clean:
-	$(RM) $(OBJS) $(DEPS)
-	+$(MAKE) -C $(LIBFT_DIR) clean
+	@$(RM) $(OBJS)
+	@$(RM) $(SRCS:%.c=%.o.tmp) 
+	@+$(MAKE) -C $(LIBFT_DIR) clean
 
 fclean: clean
 	$(RM) $(NAME)

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -52,6 +52,7 @@ void tokenize_error(const char *location, char **rest, char *line);
 void parse_error(const char *location, t_token **rest, t_token *tok);
 void xperror(const char *location);
 void builtin_error(const char *func, const char *name, const char *err);
+void command_not_found_error(const char *location);
 
 // tokenize.c
 typedef struct s_token t_token;

--- a/libft/Makefile
+++ b/libft/Makefile
@@ -63,19 +63,20 @@ endif
 all: $(NAME)
 
 $(NAME): $(OBJ)
-	$(AR) $@ $^
+	@$(AR) $@ $^
 
 bonus: $(OBJCB)
-	$(AR) $(NAME) $^
+	@$(AR) $(NAME) $^
 
 %.o: %.c libft.h
-	$(CC) $(CFLAGS) -c $< -o $@
+	@$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-		 $(RM) $(OBJC) $(OBJCB)
+		@$(RM) $(OBJC) $(OBJCB)
+		@$(RM) $(SRCS:%.c=%.o.tmp) 
 
 fclean: clean
-		$(RM) $(NAME)
+		@$(RM) $(NAME)
 
 re: fclean all
 .PHONY: all clean fclean re bonus

--- a/srcs/error_handler/error.c
+++ b/srcs/error_handler/error.c
@@ -98,3 +98,8 @@ void	builtin_error(const char *func, const char *name, const char *err)
 		dprintf(STDERR_FILENO, "%s: ", name);
 	dprintf(STDERR_FILENO, "%s\n", err);
 }
+
+void	command_not_found_error(const char *location)
+{
+	print_error(location, "command not found");
+}


### PR DESCRIPTION
This pull request introduces improvements to error handling and the Makefile system in the project. The most significant changes are the addition of a dedicated error function for "command not found" cases, refactoring of the non-builtin command execution logic to use this new function, and enhancements to the Makefile for cleaner output and better cleanup.

**Error handling improvements:**

* Added a new function `command_not_found_error` in `error.c` to standardize the error message for cases where a command is not found. The function is declared in `minishell.h` and used throughout the codebase. [[1]](diffhunk://#diff-6d0554511fc95acea820d9092ccbd0a9ea8fdeb0583c874613220026a7ac62f8R101-R105) [[2]](diffhunk://#diff-29c141a418b83334b1dd8ff9066c9fb218e84e274d4381095f6aecb05b8fc5daR55)
* Refactored `exec_nonbuiltin` in `exec.c` to use `command_not_found_error` instead of `print_error` when a command is not found, and improved the logic to handle empty or NULL command paths.

**unimportant but ...**
Makefile and build system enhancements:
* Updated the main `Makefile` and `libft/Makefile` to use `@` before commands for quieter output, added cleanup of temporary `.o.tmp` files, and improved the `clean` and `fclean` targets for more thorough cleanup. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L84-R95) [[2]](diffhunk://#diff-317d5c4a27e48a3950ecf4b5f845fc6683ed69fc5114c7372509e6679d88f881L66-R79)

----

**Reference (bash)**
```bash
$ """"
-bash: : command not found
$ ""
-bash: : command not found
$ $?
-bash: 127: command not found
```
**Actual (minishell)**
```bash
$ ./minishell
minishell$ """"
minishell: : command not found
minishell$ ""
minishell: : command not found
minishell$ $?
minishell: 127: command not found
```