### PR TITLE
Print 'command not found' for empty location

### DIFF
--- a/srcs/error_handler/error.c
+++ b/srcs/error_handler/error.c
@@ -59,6 +59,6 @@ void	todo(const char *msg)
 void	command_not_found_error(const char *location)
 {
 	if (location == NULL || *location == '\0')
-		return ;
+		location = "";
 	print_error(location, "command not found");
 }


### PR DESCRIPTION
Previously the function returned early when location was NULL or empty, suppressing the error. Set location to an empty string so print_error is always called.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message reporting by ensuring command-related errors are consistently displayed, even when location information is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->