### PR TITLE
**bultin_unset** 

### DIFF
--- a/srcs/builtin/builtin_export.c
+++ b/srcs/builtin/builtin_export.c
@@ -46,8 +46,7 @@ int	builtin_export(t_shell *shell, char **argv)
 		if (map_put(shell->envmap, argv[i], true) < 0)
 		{
 			builtin_error("export", argv[i], "not a valid identifier");
-			status = 1;
-		}
+			status = 1;		}
 		i++;
 	}
 	return (status);

--- a/srcs/builtin/builtin_export.c
+++ b/srcs/builtin/builtin_export.c
@@ -46,7 +46,8 @@ int	builtin_export(t_shell *shell, char **argv)
 		if (map_put(shell->envmap, argv[i], true) < 0)
 		{
 			builtin_error("export", argv[i], "not a valid identifier");
-			status = 1;		}
+			status = 1;
+		}
 		i++;
 	}
 	return (status);

--- a/srcs/builtin/builtin_unset.c
+++ b/srcs/builtin/builtin_unset.c
@@ -23,8 +23,7 @@ int	builtin_unset(t_shell *shell, char **argv)
 	{
 		if (map_unset(shell->envmap, argv[i]) < 0)
 		{
-			builtin_error("unset", argv[i], "not a valid identifier");
-			status = 1;
+			status = 0;
 		}
 		else
 			status = 0;

--- a/srcs/exec/exec_resolve.c
+++ b/srcs/exec/exec_resolve.c
@@ -18,7 +18,8 @@
 static void	handle_resolve_error(char *path, char **argv,
 	const char *errmsg, int exit_code)
 {
-	print_error(*argv, errmsg);
+	if (!(argv[0] == NULL))
+		print_error(*argv, errmsg);
 	if (path != argv[0])
 		free(path);
 	free_argv(argv);


### PR DESCRIPTION
**bultin_unset** 
```
 status=1
else
 status=1 
```
this is concious for Extensibility.

**builtin_resolve** 
``` 
if (argv[0] != NULL)
 print_error(*argv, errmsg);
```
this change will avoid `(null)` error messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added null pointer protection in command resolution error handling.
  * Modified error status reporting behavior in built-in commands.
  * Adjusted error handling logic for the unset operation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->